### PR TITLE
Determine tipswitch value from pressure input

### DIFF
--- a/src/AmtPtpDeviceUsbKm/Interrupt.c
+++ b/src/AmtPtpDeviceUsbKm/Interrupt.c
@@ -209,7 +209,7 @@ AmtPtpEvtUsbInterruptPipeReadComplete(
 			PtpReport.Contacts[i].ContactID = (UCHAR) i;
 			PtpReport.Contacts[i].X = x;
 			PtpReport.Contacts[i].Y = y;
-			PtpReport.Contacts[i].TipSwitch = f->Pressure != 0;
+			PtpReport.Contacts[i].TipSwitch = f->pressure != 0;
 			PtpReport.Contacts[i].Confidence = (AmtRawToInteger(f->touch_minor) << 1) > 0;
 		}
 	}

--- a/src/AmtPtpDeviceUsbKm/Interrupt.c
+++ b/src/AmtPtpDeviceUsbKm/Interrupt.c
@@ -209,7 +209,7 @@ AmtPtpEvtUsbInterruptPipeReadComplete(
 			PtpReport.Contacts[i].ContactID = (UCHAR) i;
 			PtpReport.Contacts[i].X = x;
 			PtpReport.Contacts[i].Y = y;
-			PtpReport.Contacts[i].TipSwitch = (AmtRawToInteger(f->touch_major) << 1) >= 200 || (AmtRawToInteger(f->touch_minor) << 1) >= 150;
+			PtpReport.Contacts[i].TipSwitch = f->Pressure != 0;
 			PtpReport.Contacts[i].Confidence = (AmtRawToInteger(f->touch_minor) << 1) > 0;
 		}
 	}

--- a/src/AmtPtpDeviceUsbUm/InputInterrupt.c
+++ b/src/AmtPtpDeviceUsbUm/InputInterrupt.c
@@ -335,7 +335,7 @@ AmtPtpServiceTouchInputInterrupt(
 			PtpReport.Contacts[i].ContactID = (UCHAR) i;
 			PtpReport.Contacts[i].X = x;
 			PtpReport.Contacts[i].Y = y;
-			PtpReport.Contacts[i].TipSwitch = f->Pressure != 0;
+			PtpReport.Contacts[i].TipSwitch = f->pressure != 0;
 			PtpReport.Contacts[i].Confidence = (AmtRawToInteger(f->touch_minor) << 1) > 0;
 
 #ifdef INPUT_CONTENT_TRACE

--- a/src/AmtPtpDeviceUsbUm/InputInterrupt.c
+++ b/src/AmtPtpDeviceUsbUm/InputInterrupt.c
@@ -335,7 +335,7 @@ AmtPtpServiceTouchInputInterrupt(
 			PtpReport.Contacts[i].ContactID = (UCHAR) i;
 			PtpReport.Contacts[i].X = x;
 			PtpReport.Contacts[i].Y = y;
-			PtpReport.Contacts[i].TipSwitch = (AmtRawToInteger(f->touch_major) << 1) >= 200;
+			PtpReport.Contacts[i].TipSwitch = f->Pressure != 0;
 			PtpReport.Contacts[i].Confidence = (AmtRawToInteger(f->touch_minor) << 1) > 0;
 
 #ifdef INPUT_CONTENT_TRACE
@@ -515,7 +515,7 @@ AmtPtpServiceTouchInputInterruptType5(
 			PtpReport.Contacts[i].ContactID = f_type5->ContactIdentifier.Id;
 			PtpReport.Contacts[i].X = (USHORT) x;
 			PtpReport.Contacts[i].Y = (USHORT) y;
-			PtpReport.Contacts[i].TipSwitch = (AmtRawToInteger(f_type5->TouchMajor) << 1) > 0;
+			PtpReport.Contacts[i].TipSwitch = f_type5->Pressure != 0;
 
 			// The Microsoft spec says reject any input larger than 25mm. This is not ideal
 			// for Magic Trackpad 2 - so we raised the threshold a bit higher.

--- a/src/AmtPtpHidFilter/Input.c
+++ b/src/AmtPtpHidFilter/Input.c
@@ -210,7 +210,7 @@ PtpFilterInputRequestCompletionCallback(
 		ptpOutputReport.Contacts[i].ContactID = f_type5->OrientationAndOrigin.ContactIdentifier.Id;
 		ptpOutputReport.Contacts[i].X = (USHORT)x;
 		ptpOutputReport.Contacts[i].Y = (USHORT)y;
-		PtpReport.Contacts[i].TipSwitch = f_type5->Pressure != 0;
+		ptpOutputReport.Contacts[i].TipSwitch = f_type5->Pressure != 0;
 		// The Microsoft spec says reject any input larger than 25mm. This is not ideal
 		// for Magic Trackpad 2 - so we raised the threshold a bit higher.
 		// Or maybe I used the wrong unit? IDK

--- a/src/AmtPtpHidFilter/Input.c
+++ b/src/AmtPtpHidFilter/Input.c
@@ -210,7 +210,7 @@ PtpFilterInputRequestCompletionCallback(
 		ptpOutputReport.Contacts[i].ContactID = f_type5->OrientationAndOrigin.ContactIdentifier.Id;
 		ptpOutputReport.Contacts[i].X = (USHORT)x;
 		ptpOutputReport.Contacts[i].Y = (USHORT)y;
-		ptpOutputReport.Contacts[i].TipSwitch = ((signed short) (f_type5->TouchMajor) << 1) > 0;
+		PtpReport.Contacts[i].TipSwitch = f_type5->Pressure != 0;
 		// The Microsoft spec says reject any input larger than 25mm. This is not ideal
 		// for Magic Trackpad 2 - so we raised the threshold a bit higher.
 		// Or maybe I used the wrong unit? IDK


### PR DESCRIPTION
This update resolves the issue with hovering causing cursor jitter, unintended taps, etc. 

I have only tested this out on x64 with a Magic Trackpad 2 with the User Mode Driver. If we could test out the other cases I think this would be ready to merge (unless the maintainers are confident with the changes made in this PR):

1. Magic Trackpad 1 | User Mode, Kernel Mode
2. Magic Trackpad 2 | Kernel Mode